### PR TITLE
support for live templates - defines group "xquery" and "XQUERY_CODE" context

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Michal Jedynak <m.jedynak@gmail.com> - Issue #22 - Duplicate declarations code i
 Arnost Valicek <arnost.valicek@gmail.com> - Issue #72 - Structure view should be able to filter-out non-public functions and variables
 Arnost Valicek <arnost.valicek@gmail.com> - Issue #50 - Folding of functions
 Arnost Valicek <arnost.valicek@gmail.com> - Issue #23 - Imports and namespaces declarations folding
+Arnost Valicek <arnost.valicek@gmail.com> - Issue #91 - XQuery context for live templates

--- a/src/main/java/org/intellij/xquery/livetemplate/XQueryContextType.java
+++ b/src/main/java/org/intellij/xquery/livetemplate/XQueryContextType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2014 Grzegorz Ligas <ligasgr@gmail.com> and other contributors
+ * (see the CONTRIBUTORS file).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.xquery.livetemplate;
+
+import com.intellij.codeInsight.template.EverywhereContextType;
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiUtilBase;
+import org.intellij.xquery.XQueryLanguage;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class XQueryContextType extends TemplateContextType {
+
+    protected XQueryContextType(@NotNull @NonNls String id, @NotNull String presentableName, @Nullable Class<? extends TemplateContextType> baseContextType) {
+        super(id, presentableName, baseContextType);
+    }
+
+    @Override
+    public boolean isInContext(@NotNull PsiFile file, int offset) {
+        if (!PsiUtilBase.getLanguageAtOffset(file, offset).isKindOf(XQueryLanguage.INSTANCE)) return false;
+        PsiElement element = file.findElementAt(offset);
+        if (element instanceof PsiWhiteSpace) {
+            return false;
+        }
+        return element != null && isInContext(element);
+    }
+
+    protected abstract boolean isInContext(PsiElement element);
+
+
+
+    public static class Generic extends XQueryContextType {
+
+        protected Generic() {
+            super("XQUERY_CODE", "XQuery", EverywhereContextType.class);
+        }
+
+        @Override
+        protected boolean isInContext(PsiElement element) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/intellij/xquery/livetemplate/XQueryLiveTemplatesProvider.java
+++ b/src/main/java/org/intellij/xquery/livetemplate/XQueryLiveTemplatesProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2014 Grzegorz Ligas <ligasgr@gmail.com> and other contributors
+ * (see the CONTRIBUTORS file).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.xquery.livetemplate;
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider;
+import com.intellij.util.ArrayUtil;
+
+public class XQueryLiveTemplatesProvider implements DefaultLiveTemplatesProvider {
+
+    public static final String[] TEMPLATE_FILES = {"liveTemplates/xquery"};
+
+    @Override
+    public String[] getDefaultLiveTemplateFiles() {
+        return TEMPLATE_FILES;
+    }
+
+    @Override
+    public String[] getHiddenLiveTemplateFiles() {
+        return ArrayUtil.EMPTY_STRING_ARRAY;
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,6 +55,10 @@
         <lang.formatter language="XQuery" implementationClass="org.intellij.xquery.formatter.XQueryFormattingModelBuilder"/>
         <lang.foldingBuilder language="XQuery" implementationClass="org.intellij.xquery.folding.XQueryFoldingBuilder"/>
         <codeStyleSettingsProvider implementation="org.intellij.xquery.formatter.settings.XQueryCodeStyleSettingsProvider"/>
+
+        <defaultLiveTemplatesProvider implementation="org.intellij.xquery.livetemplate.XQueryLiveTemplatesProvider"/>
+        <liveTemplateContext implementation="org.intellij.xquery.livetemplate.XQueryContextType$Generic"/>
+
         <langCodeStyleSettingsProvider implementation="org.intellij.xquery.formatter.settings.XQueryLanguageCodeStyleSettingsProvider"/>
         <quoteHandler fileType="XQuery file" className="org.intellij.xquery.quotes.XQueryQuoteHandler"/>
         <declarationRangeHandler key="org.intellij.xquery.psi.XQueryFunctionDecl" implementationClass="org.intellij.xquery.structure.XQueryFunctionDeclarationRangeHandler"/>

--- a/src/main/resources/liveTemplates/xquery.xml
+++ b/src/main/resources/liveTemplates/xquery.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templateSet group="xquery">
+
+    <template name="declvar" value="declare variable $$$NAME$ := $VALUE$;" description="declare variable" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="VALUE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="XQUERY_CODE" value="true" />
+        </context>
+    </template>
+
+</templateSet>
+

--- a/src/testFunctional/java/org/intellij/xquery/livetemplate/LiveTemplateTest.java
+++ b/src/testFunctional/java/org/intellij/xquery/livetemplate/LiveTemplateTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2014 Grzegorz Ligas <ligasgr@gmail.com> and other contributors
+ * (see the CONTRIBUTORS file).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.xquery.livetemplate;
+
+import com.intellij.codeInsight.lookup.Lookup;
+import com.intellij.codeInsight.lookup.LookupManager;
+import com.intellij.codeInsight.lookup.impl.LookupImpl;
+import com.intellij.codeInsight.template.impl.actions.ListTemplatesAction;
+import com.intellij.openapi.editor.Editor;
+import org.intellij.xquery.BaseFunctionalTestCase;
+import org.junit.Test;
+
+public class LiveTemplateTest extends BaseFunctionalTestCase {
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/testFunctional/testData/org/intellij/xquery/livetemplate";
+    }
+
+    @Test
+    public void testDeclareVariableTemplate() throws Exception {
+        doTest();
+    }
+
+    private void doTest() throws Exception {
+        final String testName = getTestName(false);
+        myFixture.configureByFile(testName + ".xq");
+        expandTemplate(myFixture.getEditor());
+        myFixture.checkResultByFile(String.format("%s_after.xq", testName));
+    }
+
+    public void expandTemplate(final Editor editor) {
+        new ListTemplatesAction().actionPerformedImpl(editor.getProject(), editor);
+        ((LookupImpl) LookupManager.getActiveLookup(editor)).finishLookup(Lookup.NORMAL_SELECT_CHAR);
+    }
+
+}

--- a/src/testFunctional/testData/org/intellij/xquery/livetemplate/DeclareVariableTemplate.xq
+++ b/src/testFunctional/testData/org/intellij/xquery/livetemplate/DeclareVariableTemplate.xq
@@ -1,0 +1,4 @@
+xquery version "3.0";
+module namespace DeclareVariableTemplate = "DeclareVariableTemplate";
+
+declvar<caret>

--- a/src/testFunctional/testData/org/intellij/xquery/livetemplate/DeclareVariableTemplate_after.xq
+++ b/src/testFunctional/testData/org/intellij/xquery/livetemplate/DeclareVariableTemplate_after.xq
@@ -1,0 +1,4 @@
+xquery version "3.0";
+module namespace DeclareVariableTemplate = "DeclareVariableTemplate";
+
+declare variable $ := ;


### PR DESCRIPTION
Initial support, only generic "XQUERY_CODE" context is defined. It may be useful to define additional
context, e.g context for templates defined only within function declaration
