### PR TITLE
Updated plugin.xml to support IntelliJ 14.1. Updated import of HelpID in XQueryFindUsageProvider.

### DIFF
--- a/src/main/java/org/intellij/xquery/usage/XQueryFindUsageProvider.java
+++ b/src/main/java/org/intellij/xquery/usage/XQueryFindUsageProvider.java
@@ -17,7 +17,7 @@
 
 package org.intellij.xquery.usage;
 
-import com.intellij.find.impl.HelpID;
+import com.intellij.lang.HelpID;
 import com.intellij.lang.cacheBuilder.DefaultWordsScanner;
 import com.intellij.lang.cacheBuilder.WordsScanner;
 import com.intellij.lang.findUsages.FindUsagesProvider;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,25 +18,21 @@
 <idea-plugin url="http://ligasgr.github.io/intellij-xquery/" version="2">
     <id>org.intellij.xquery</id>
     <name>XQuery Support</name>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <vendor email="ligasgr@gmail.com" url="http://grzegorzligas.blogspot.com/">Grzegorz Ligas</vendor>
 
     <description>Provides support for XQuery language in version 3.0</description>
 
     <change-notes>
         <![CDATA[
-            <p>2.2.0:</p>
+            <p>2.2.1:</p>
             <ul>
-                <li>Improve insertion of completed items with namespace prefix.</li>
-                <li>Improve completion of functions and variables when prefix and part of the name are present.</li>
-                <li>Issue <a href="https://github.com/ligasgr/intellij-xquery/issues/110">#110</a> - Add backwards compatibility with Marklogic language extensions.</li>
-                <li>Issue <a href="https://github.com/ligasgr/intellij-xquery/issues/111">#111</a> - Color Issues.</li>
-                <li>Issue <a href="https://github.com/ligasgr/intellij-xquery/issues/112">#112</a> - Faulty error reported using ml-1.0 syntax.</li>
+                <li>Added support for IntelliJ 14.1</li>
             </ul>
         ]]>
     </change-notes>
 
-    <idea-version since-build="132.947" until-build="139.9999"/>
+    <idea-version since-build="141.177" until-build="141.9999"/>
 
     <depends>com.intellij.modules.lang</depends>
     <depends optional="true" config-file="java-lang.xml">com.intellij.modules.java</depends>


### PR DESCRIPTION
The location of FIND_OTHER_USAGES has been changed in 14.1. Unfortunatelly, merging this pull request will cause a break in backward compatibility.